### PR TITLE
Fix onboarding and auth routing for user journeys

### DIFF
--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -19,7 +19,7 @@ class AppRouter {
   final AuthService _authService;
 
   late final GoRouter router = GoRouter(
-    initialLocation: '/home',
+    initialLocation: '/welcome',
     refreshListenable: _authService,
     routes: <RouteBase>[
       GoRoute(
@@ -54,15 +54,19 @@ class AppRouter {
       ),
     ],
     redirect: (context, state) {
+      final status = _authService.status;
       final loggedIn = _authService.isUserLoggedIn();
-      final loggingIn = state.matchedLocation == '/login' ||
-          state.matchedLocation == '/register';
+      final loggingIn = state.matchedLocation == '/login' || state.matchedLocation == '/register';
       final onWelcome = state.matchedLocation == '/welcome';
+
+      if (status == AuthStatus.unknown) {
+        return onWelcome ? null : '/welcome';
+      }
 
       if (!loggedIn && !loggingIn && !onWelcome) {
         return '/login';
       }
-      if (loggedIn && loggingIn) {
+      if (loggedIn && (loggingIn || onWelcome)) {
         return '/home';
       }
       return null;

--- a/lib/screens/welcome_screen.dart
+++ b/lib/screens/welcome_screen.dart
@@ -27,7 +27,7 @@ class WelcomeScreen extends StatelessWidget {
               ),
               const SizedBox(height: 24),
               FilledButton(
-                onPressed: () => context.goNamed('home'),
+                onPressed: () => context.goNamed('login'),
                 child: Text(l10n.welcomeStartButton),
               ),
             ],


### PR DESCRIPTION
### Motivation
- Users experienced confusing or broken navigation during onboarding and auth state hydration because the router started on `/home` and redirects did not account for an `unknown` auth state.
- The welcome CTA led guests into a protected route, creating redirect loops and poor first-run UX.

### Description
- Set the router `initialLocation` to `/welcome` to make the onboarding entry point deterministic for first-time and returning users.
- Added handling for `AuthStatus.unknown` in the router `redirect` so the app stays on `/welcome` while auth state hydrates.
- Updated redirect logic to send unauthenticated users to `/login` for protected routes and to send authenticated users away from `/welcome`, `/login`, and `/register` to `/home`.
- Changed the `WelcomeScreen` CTA to navigate to `login` instead of `home` to avoid immediate protected-route navigation for guests.

### Testing
- Attempted to run `flutter test`, but the Flutter SDK is not available in the execution environment (`flutter: command not found`), so widget/unit tests could not be executed.
- Performed a static check of the web JS bundle with `node --check web/app.js`, which completed without syntax errors.
- Verified file changes and inspected the updated Dart sources via file content listings to confirm the applied edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfcea817ec832ab2f25bbbf70d310d)